### PR TITLE
api 만들기

### DIFF
--- a/haveit/build.gradle
+++ b/haveit/build.gradle
@@ -23,6 +23,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+    implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'

--- a/haveit/src/main/java/com/mhc/haveit/config/SecurityConfig.java
+++ b/haveit/src/main/java/com/mhc/haveit/config/SecurityConfig.java
@@ -1,0 +1,17 @@
+package com.mhc.haveit.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception{
+        return http
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())       // TODO: 스프링 시큐리티 적용시 바꿔야 합니다
+                .build();
+    }
+}

--- a/haveit/src/main/java/com/mhc/haveit/repository/ArticleRepository.java
+++ b/haveit/src/main/java/com/mhc/haveit/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.mhc.haveit.repository;
 
 import com.mhc.haveit.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/haveit/src/main/java/com/mhc/haveit/repository/CommentRepository.java
+++ b/haveit/src/main/java/com/mhc/haveit/repository/CommentRepository.java
@@ -2,6 +2,8 @@ package com.mhc.haveit.repository;
 
 import com.mhc.haveit.domain.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface CommentRepository extends JpaRepository<Comment, Long> {
 }

--- a/haveit/src/main/java/com/mhc/haveit/repository/HabitRegistrationRepository.java
+++ b/haveit/src/main/java/com/mhc/haveit/repository/HabitRegistrationRepository.java
@@ -2,6 +2,8 @@ package com.mhc.haveit.repository;
 
 import com.mhc.haveit.domain.HabitRegistration;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface HabitRegistrationRepository extends JpaRepository<HabitRegistration, Long> {
 }

--- a/haveit/src/main/java/com/mhc/haveit/repository/HabitRepository.java
+++ b/haveit/src/main/java/com/mhc/haveit/repository/HabitRepository.java
@@ -2,6 +2,8 @@ package com.mhc.haveit.repository;
 
 import com.mhc.haveit.domain.Habit;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface HabitRepository extends JpaRepository<Habit, Long>{
 }

--- a/haveit/src/main/java/com/mhc/haveit/repository/UserAccountRepository.java
+++ b/haveit/src/main/java/com/mhc/haveit/repository/UserAccountRepository.java
@@ -2,6 +2,8 @@ package com.mhc.haveit.repository;
 
 import com.mhc.haveit.domain.UserAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface UserAccountRepository extends JpaRepository<UserAccount, Long> {
 }

--- a/haveit/src/main/resources/application.yaml
+++ b/haveit/src/main/resources/application.yaml
@@ -23,4 +23,6 @@ spring:
       hibernate.default_batch_fetch_size: 100
   h2.console.enabled: true
   sql.init.mode: always
-
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated

--- a/haveit/src/test/java/com/mhc/haveit/controller/DataRestTest.java
+++ b/haveit/src/test/java/com/mhc/haveit/controller/DataRestTest.java
@@ -1,0 +1,71 @@
+package com.mhc.haveit.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@DisplayName("Data REST - API 테스트")
+@Transactional                          // 데이터베이스를 직접 건드릴 수 있으므로 안전하게 롤백을 하기위해
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 습관 리스트 조회")
+    @Test
+    void givenNothing_whenRequesting_thenReturnsHabitsResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/habits"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));   // json 과는 달라 직접 설정
+    }
+
+    @DisplayName("[api] 습관 단건 조회")
+    @Test
+    void givenNothing_whenRequesting_thenReturnsHabitResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/habits/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 습관의 게시글 리스트 조회")
+    @Test
+    void givenNothing_whenRequesting_thenReturnsHabitArticlesResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/habits/1/articles"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글의 댓글 리스트 조회")
+    @Test
+    void givenNothing_whenRequesting_thenReturnsArticleCommentsResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles/1/comments"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+}

--- a/haveit/src/test/java/com/mhc/haveit/controller/DataRestTest.java
+++ b/haveit/src/test/java/com/mhc/haveit/controller/DataRestTest.java
@@ -1,5 +1,6 @@
 package com.mhc.haveit.controller;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@Disabled("Spring Data REST 통합테스트는 불필요하므로 제외시킴")
 @DisplayName("Data REST - API 테스트")
 @Transactional                          // 데이터베이스를 직접 건드릴 수 있으므로 안전하게 롤백을 하기위해
 @AutoConfigureMockMvc


### PR DESCRIPTION
SpringDataRest + HALexplorer
를 사용하여 간단하게 api 를 만들었습니다.

이 프로젝트의 비즈니스 로직으로 구현한 내용이 아니고
data rest 기능을 사용하였습니다.
공부 목적으로 만들었기 때문에 삭제하지 않고
테스트에서 제외 처리해서 전체 테스트 중에 실행되지 않게 끔 처리하였습니다.

* SpringDataRest 는 api 를 자동으로 RESTful 하게 생성해 줍니다.
* HALexplorer 은 api 를 간단하게 테스하기위해 추가하였습니다.
