### PR TITLE
기능구현하기 (습관목록 페이지)

### DIFF
--- a/haveit/build.gradle
+++ b/haveit/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-rest'
     implementation 'org.springframework.data:spring-data-rest-hal-explorer'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/haveit/src/main/java/com/mhc/haveit/controller/HabitController.java
+++ b/haveit/src/main/java/com/mhc/haveit/controller/HabitController.java
@@ -1,18 +1,46 @@
 package com.mhc.haveit.controller;
 
+import com.mhc.haveit.domain.type.SearchType;
+import com.mhc.haveit.dto.HabitDto;
+import com.mhc.haveit.service.HabitService;
+import com.mhc.haveit.service.PaginationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 @RequestMapping("/habits")
 @Controller
 public class HabitController {
+
+    private final HabitService habitService;
+    private final PaginationService paginationService;
+
+    private final int DEFAULT_SIZE = 12;
+
     @GetMapping
-    public String habits(ModelMap map){
-        map.addAttribute("habits", List.of());  // TODO : service 구현 시 바꿔야 함
+    public String habits(
+            @RequestParam(required = false) SearchType searchType,
+            @RequestParam(required = false) String searchKeyword,
+            @PageableDefault(size = DEFAULT_SIZE, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            ModelMap map
+    ) {
+        Page<HabitDto> habits = habitService.searchHabits(searchType, searchKeyword, pageable);
+        List<Integer> barNumber = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), habits.getTotalPages());
+
+        map.addAttribute("habits", habits);
+        map.addAttribute("paginationBarNumbers",barNumber);
+        map.addAttribute("searchTypes",SearchType.values());
+
         return "habits/index";
     }
 }

--- a/haveit/src/main/java/com/mhc/haveit/controller/HabitController.java
+++ b/haveit/src/main/java/com/mhc/haveit/controller/HabitController.java
@@ -1,9 +1,18 @@
 package com.mhc.haveit.controller;
 
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
 
 @RequestMapping("/habits")
 @Controller
 public class HabitController {
+    @GetMapping
+    public String habits(ModelMap map){
+        map.addAttribute("habits", List.of());  // TODO : service 구현 시 바꿔야 함
+        return "habits/index";
+    }
 }

--- a/haveit/src/main/java/com/mhc/haveit/controller/HabitController.java
+++ b/haveit/src/main/java/com/mhc/haveit/controller/HabitController.java
@@ -1,0 +1,9 @@
+package com.mhc.haveit.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/habits")
+@Controller
+public class HabitController {
+}

--- a/haveit/src/main/java/com/mhc/haveit/domain/type/SearchType.java
+++ b/haveit/src/main/java/com/mhc/haveit/domain/type/SearchType.java
@@ -1,0 +1,15 @@
+package com.mhc.haveit.domain.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SearchType {
+    TITLE("제목"),
+    ID("아이디"),
+    NICKNAME("닉네임"),
+    HASHTAG("해시태그");
+
+    private final String description;
+}

--- a/haveit/src/main/java/com/mhc/haveit/dto/ArticleDto.java
+++ b/haveit/src/main/java/com/mhc/haveit/dto/ArticleDto.java
@@ -1,0 +1,30 @@
+package com.mhc.haveit.dto;
+
+import com.mhc.haveit.domain.Article;
+import com.mhc.haveit.domain.UserAccount;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ArticleDto implements Serializable{
+    private Long id;
+    private Long habitId;
+    private UserAccountDto userAccountDto;
+    private String title;
+    private String content;
+
+    public ArticleDto from(Article entity){
+        return ArticleDto.builder()
+                .id(entity.getId())
+                .habitId(entity.getHabit().getId())
+                .userAccountDto(UserAccountDto.from(entity.getUserAccount()))
+                .title(entity.getTitle())
+                .content(entity.getContent())
+                .build();
+    }
+
+}

--- a/haveit/src/main/java/com/mhc/haveit/dto/HabitDto.java
+++ b/haveit/src/main/java/com/mhc/haveit/dto/HabitDto.java
@@ -1,0 +1,52 @@
+package com.mhc.haveit.dto;
+
+import com.mhc.haveit.domain.Habit;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class HabitDto implements Serializable {
+
+    private Long id;
+    private String name;
+    private UserAccountDto userAccountDto;
+    private ArticleDto articleDto;
+    private String content;
+    private String hashtag;
+    private LocalDateTime endDate;
+    private LocalDateTime createdAt;
+    private String createdBy;
+    private LocalDateTime modifiedAt;
+    private String modifiedBy;
+
+    public static HabitDto from(Habit entity){
+        return HabitDto.builder()
+                .id(entity.getId())
+                .name(entity.getName())
+                .userAccountDto(UserAccountDto.from(entity.getUserAccount()))
+                .content(entity.getContent())
+                .hashtag(entity.getHashtag())
+                .endDate(entity.getEndDate())
+                .createdAt(entity.getCreatedAt())
+                .createdBy(entity.getCreatedBy())
+                .modifiedAt(entity.getModifiedAt())
+                .modifiedBy(entity.getModifiedBy())
+                .build();
+    }
+
+    public Habit toEntity() {
+        return Habit.builder()
+                .id(id)
+                .name(name)
+                .userAccount(userAccountDto.toEntity())
+                .content(content)
+                .hashtag(hashtag)
+                .endDate(endDate)
+                .build();
+    }
+}

--- a/haveit/src/main/java/com/mhc/haveit/dto/UserAccountDto.java
+++ b/haveit/src/main/java/com/mhc/haveit/dto/UserAccountDto.java
@@ -1,0 +1,51 @@
+package com.mhc.haveit.dto;
+
+import com.mhc.haveit.domain.UserAccount;
+import lombok.*;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserAccountDto implements Serializable {
+
+    private Long id;
+    private String userId;
+    private String userPassword;
+    private String nickname;
+    private String email;
+    private String memo;
+    private LocalDateTime createdAt;
+    private String createdBy;
+    private LocalDateTime modifiedAt;
+    private String modifiedBy;
+
+    public static UserAccountDto from(UserAccount entity){
+        return UserAccountDto.builder()
+                .id(entity.getId())
+                .userId(entity.getUserId())
+                .userPassword(entity.getUserPassword())
+                .nickname(entity.getNickname())
+                .email(entity.getEmail())
+                .memo(entity.getMemo())
+                .createdAt(entity.getCreatedAt())
+                .createdBy(entity.getCreatedBy())
+                .modifiedAt(entity.getModifiedAt())
+                .modifiedBy(entity.getModifiedBy())
+                .build();
+    }
+
+    public UserAccount toEntity() {
+        return UserAccount.builder()
+                .id(id)
+                .userId(userId)
+                .userPassword(userPassword)
+                .nickname(nickname)
+                .email(email)
+                .memo(memo)
+                .build();
+    }
+}

--- a/haveit/src/main/java/com/mhc/haveit/repository/HabitRepository.java
+++ b/haveit/src/main/java/com/mhc/haveit/repository/HabitRepository.java
@@ -1,9 +1,15 @@
 package com.mhc.haveit.repository;
 
 import com.mhc.haveit.domain.Habit;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 @RepositoryRestResource
 public interface HabitRepository extends JpaRepository<Habit, Long>{
+    Page<Habit> findByNameContaining(String keyword, Pageable pageable);
+    Page<Habit> findByUserAccount_UserIdContaining(String keyword, Pageable pageable);
+    Page<Habit> findByUserAccount_NicknameContaining(String keyword, Pageable pageable);
+    Page<Habit> findByHashtagContaining(String keyword, Pageable pageable);
 }

--- a/haveit/src/main/java/com/mhc/haveit/service/HabitService.java
+++ b/haveit/src/main/java/com/mhc/haveit/service/HabitService.java
@@ -1,0 +1,66 @@
+package com.mhc.haveit.service;
+
+import com.mhc.haveit.domain.Habit;
+import com.mhc.haveit.domain.type.SearchType;
+import com.mhc.haveit.dto.HabitDto;
+import com.mhc.haveit.repository.HabitRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional
+@Service
+public class HabitService {
+
+    private final HabitRepository habitRepository;
+
+    @Transactional(readOnly = true)
+    public Page<HabitDto> searchHabits(SearchType searchType, String searchKeyword, Pageable pageable){
+        if(searchKeyword == null || searchKeyword.isBlank()){
+            return habitRepository.findAll(pageable).map(HabitDto::from);
+        }
+        return switch (searchType){
+            case TITLE ->  habitRepository.findByNameContaining(searchKeyword,pageable).map(HabitDto::from);
+            case ID -> habitRepository.findByUserAccount_UserIdContaining(searchKeyword,pageable).map(HabitDto::from);
+            case NICKNAME -> habitRepository.findByUserAccount_NicknameContaining(searchKeyword,pageable).map(HabitDto::from);
+            case HASHTAG -> habitRepository.findByHashtagContaining(searchKeyword,pageable).map(HabitDto::from);
+        };
+    }
+
+    @Transactional(readOnly = true)
+    public HabitDto getHabit(Long habitId) {
+        return habitRepository.findById(habitId)
+                .map(HabitDto::from)
+                .orElseThrow(()-> new EntityNotFoundException("존재하지 않는 습관입니다. - habitId:"+habitId));
+    }
+
+    public void saveHabit(HabitDto dto) {
+        habitRepository.save(dto.toEntity());
+    }
+
+    public void updateHabit(HabitDto dto) {
+        Optional<Habit> habit = habitRepository.findById(dto.getId());
+        habit.orElseThrow(()-> new EntityNotFoundException("습관 업데이트 실패. 습관을 찾을 수 없습니다 - dto: "+dto));
+
+        if(dto.getName() !=null){ habit.get().setName(dto.getName()); }
+        if(dto.getContent() != null){ habit.get().setContent(dto.getContent()); }
+        if(dto.getHashtag() != null){ habit.get().setHashtag(dto.getHashtag()); }
+        habitRepository.save(dto.toEntity());
+    }
+
+    public void deleteHabit(Long habitId) {
+        habitRepository.deleteById(habitId);
+    }
+
+    public Long getHabitCount() {
+        return habitRepository.count();
+    }
+}

--- a/haveit/src/main/java/com/mhc/haveit/service/PaginationService.java
+++ b/haveit/src/main/java/com/mhc/haveit/service/PaginationService.java
@@ -1,0 +1,19 @@
+package com.mhc.haveit.service;
+
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+@Service
+public class PaginationService {
+
+    private static final int BAR_LENGTH = 5;
+
+    public List<Integer> getPaginationBarNumbers(int currentPageNumber, int totalPage){
+        int startNumber = Math.max(currentPageNumber - (BAR_LENGTH/2),0);
+        int endNumber = Math.min(startNumber+BAR_LENGTH, totalPage);
+
+        return IntStream.range(startNumber,endNumber).boxed().toList();
+    }
+}

--- a/haveit/src/main/resources/templates/footer.html
+++ b/haveit/src/main/resources/templates/footer.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+
+<body>
+    <footer>
+        <hr>
+        교체된 footer
+    </footer>
+</body>
+</html>

--- a/haveit/src/main/resources/templates/habits/index.html
+++ b/haveit/src/main/resources/templates/habits/index.html
@@ -9,7 +9,77 @@
     <title>Haveit</title>
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+    <style>
+        .search-form {
+            width: 80%;
+            margin: 0 auto;
+            margin-top: 1rem;
+        }
 
+        .search-form input {
+            height: 100%;
+            background: transparent;
+            border: 0;
+            display: block;
+            width: 100%;
+            padding: 1rem;
+            height: 100%;
+            font-size: 1rem;
+        }
+
+        .search-form select {
+            background: transparent;
+            border: 0;
+            padding: 1rem;
+            height: 100%;
+            font-size: 1rem;
+        }
+
+        .search-form select:focus {
+            border: 0;
+        }
+
+        .search-form button {
+            height: 100%;
+            width: 100%;
+            font-size: 1rem;
+        }
+
+        .search-form button svg {
+            width: 24px;
+            height: 24px;
+        }
+
+        .card-margin {
+            margin-bottom: 1.875rem;
+        }
+
+        @media (min-width: 992px) {
+            .col-lg-2 {
+                flex: 0 0 16.66667%;
+                max-width: 16.66667%;
+            }
+        }
+
+        .card {
+            border: 0;
+            box-shadow: 0px 0px 10px 0px rgba(82, 63, 105, 0.1);
+            -webkit-box-shadow: 0px 0px 10px 0px rgba(82, 63, 105, 0.1);
+            -moz-box-shadow: 0px 0px 10px 0px rgba(82, 63, 105, 0.1);
+            -ms-box-shadow: 0px 0px 10px 0px rgba(82, 63, 105, 0.1);
+        }
+        .card {
+            position: relative;
+            display: flex;
+            flex-direction: column;
+            min-width: 0;
+            word-wrap: break-word;
+            background-color: #ffffff;
+            background-clip: border-box;
+            border: 1px solid #e6e4e9;
+            border-radius: 8px;
+        }
+    </style>
 </head>
 <body>
     <header th:replace="~{header :: header}"></header>
@@ -24,14 +94,15 @@
                                 <div class="col-lg-3 col-md-3 col-sm-12 p-0">
                                     <label for="search-type" hidden>검색 유형</label>
                                     <select class="form-control" id="search-type" name="searchType">
-                                        <option>제목</option>
-                                        <option>id</option>
-                                        <option>해시태그</option>
+                                        <option th:each="searchType : ${searchTypes}"
+                                                th:value="${searchType.name}"
+                                                th:text="${searchType.description}"
+                                                th:selected="${param.searchType != null && (param.searchType.toString == searchType.name)}"/>
                                     </select>
                                 </div>
                                 <div class="col-lg-8 col-md-6 col-sm-12 p-0">
                                     <label for="search-value" hidden>검색어</label>
-                                    <input type="text" placeholder="검색어..." class="form-control" id="search-value" name="searchValue">
+                                    <input type="text" placeholder="검색어..." class="form-control" id="search-value" name="searchKeyword">
                                 </div>
                                 <div class="col-lg-1 col-md-3 col-sm-12 p-0">
                                     <button type="submit" class="btn btn-base">
@@ -54,14 +125,16 @@
                 <div class="col" th:each="habit : ${habits}">
                     <div class="card shadow-sm">
                         <div class="card-body">
-                            <p class="card-text" style='overflow:hidden;white-space:nowrap;text-overflow:ellipsis' th:text="${habit.name}"></p>
-                            <p class="card-text" style='overflow:hidden;white-space:nowrap;text-overflow:ellipsis' th:text="${habit.content}"></p>
-                            <div class="d-flex justify-content-between align-items-center">
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm btn-outline-secondary" th:text="${habit.hashtag}"></button>
+                            <a style="text-decoration:none" th:href="@{'/habits/' + ${habit.id}}">
+                                <p class="card-text" style='color:black;overflow:hidden;white-space:nowrap;text-overflow:ellipsis' th:text="${habit.name}"></p>
+                                <p class="card-text" style='overflow:hidden;white-space:nowrap;text-overflow:ellipsis;color:darkgray' th:color="gray" th:text="${habit.content}"></p>
+                                <div class="d-flex justify-content-between align-items-center">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm btn-outline-secondary" th:text="${habit.hashtag}"></button>
+                                    </div>
+                                    <small class="text-muted" th:text="${#temporals.format(habit.createdAt, 'yyyy-MM-dd')}"></small>
                                 </div>
-                                <small class="text-muted" th:text="${habit.createdAt}"></small>
-                            </div>
+                            </a>
                         </div>
                     </div>
                 </div>
@@ -75,7 +148,24 @@
                 </td>
             </table>
         </nav>
-        prev 1 2 3 4 5 next
+        <nav aria-label="Page navigation example">
+            <ul class="pagination">
+                <li class="page-item">
+                    <a class="page-link"
+                       th:href="@{/habits(page=${habits.number - 1}, searchType=${param.searchType}, searchKeyword=${param.searchKeyword})}"
+                       th:class="'page-link' + (${habits.number} <= 0 ? ' disabled' : '')">이전</a></li>
+                <li class="page-item"  th:each="pageNumber : ${paginationBarNumbers}">
+                    <a class="page-link"
+                       th:text="${pageNumber + 1}"
+                       th:href="@{/habits(page=${pageNumber}, searchType=${param.searchType}, searchKeyword=${param.searchKeyword})}"
+                       th:class="'page-link' + (${pageNumber} == ${habits.number} ? ' disabled' : '')"/>
+                </li>
+                <li class="page-item">
+                    <a class="page-link"
+                       th:href="@{/habits(page=${habits.number + 1}, searchType=${param.searchType}, searchKeyword=${param.searchKeyword})}"
+                       th:class="'page-link' + (${habits.number} >= ${habits.totalPages - 1} ? ' disabled' : '')">다음</a></li>
+            </ul>
+        </nav>
     </main>
 
     <footer th:replace="~{footer :: footer}"></footer>

--- a/haveit/src/main/resources/templates/habits/index.html
+++ b/haveit/src/main/resources/templates/habits/index.html
@@ -101,8 +101,8 @@
                                     </select>
                                 </div>
                                 <div class="col-lg-8 col-md-6 col-sm-12 p-0">
-                                    <label for="search-value" hidden>검색어</label>
-                                    <input type="text" placeholder="검색어..." class="form-control" id="search-value" name="searchKeyword">
+                                    <label for="search-keyword" hidden>검색어</label>
+                                    <input type="text" placeholder="검색어..." class="form-control" id="search-keyword" name="searchKeyword" th:value="${param.searchKeyword}">
                                 </div>
                                 <div class="col-lg-1 col-md-3 col-sm-12 p-0">
                                     <button type="submit" class="btn btn-base">
@@ -128,13 +128,13 @@
                             <a style="text-decoration:none" th:href="@{'/habits/' + ${habit.id}}">
                                 <p class="card-text" style='color:black;overflow:hidden;white-space:nowrap;text-overflow:ellipsis' th:text="${habit.name}"></p>
                                 <p class="card-text" style='overflow:hidden;white-space:nowrap;text-overflow:ellipsis;color:darkgray' th:color="gray" th:text="${habit.content}"></p>
-                                <div class="d-flex justify-content-between align-items-center">
-                                    <div class="btn-group">
-                                        <button type="button" class="btn btn-sm btn-outline-secondary" th:text="${habit.hashtag}"></button>
-                                    </div>
-                                    <small class="text-muted" th:text="${#temporals.format(habit.createdAt, 'yyyy-MM-dd')}"></small>
-                                </div>
                             </a>
+                            <div class="d-flex justify-content-between align-items-center">
+                                <div class="btn-group">
+                                    <a type="button" class="btn btn-sm btn-outline-secondary" th:href="@{/habits(searchType='HASHTAG', searchKeyword=${habit.hashtag})}" th:text="${habit.hashtag}"></a>
+                                </div>
+                                <small class="text-muted" th:text="${#temporals.format(habit.createdAt, 'yyyy-MM-dd')}"></small>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/haveit/src/main/resources/templates/habits/index.html
+++ b/haveit/src/main/resources/templates/habits/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org" data-bs-theme="light">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="Mark Otto, Jacob Thornton, and Bootstrap contributors">
+    <meta name="generator" content="Hugo 0.104.2">
+    <title>Haveit</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">
+
+</head>
+<body>
+    <header th:replace="~{header :: header}"></header>
+    <main>
+    <div class="row">
+        <div class="card card-margin search-form">
+            <div class="card-body p-0">
+                <form id="search-form">
+                    <div class="row">
+                        <div class="col-12">
+                            <div class="row no-gutters">
+                                <div class="col-lg-3 col-md-3 col-sm-12 p-0">
+                                    <label for="search-type" hidden>검색 유형</label>
+                                    <select class="form-control" id="search-type" name="searchType">
+                                        <option>제목</option>
+                                        <option>id</option>
+                                        <option>해시태그</option>
+                                    </select>
+                                </div>
+                                <div class="col-lg-8 col-md-6 col-sm-12 p-0">
+                                    <label for="search-value" hidden>검색어</label>
+                                    <input type="text" placeholder="검색어..." class="form-control" id="search-value" name="searchValue">
+                                </div>
+                                <div class="col-lg-1 col-md-3 col-sm-12 p-0">
+                                    <button type="submit" class="btn btn-base">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-search">
+                                            <circle cx="11" cy="11" r="8"></circle>
+                                            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+    <div class="album py-5 bg-light">
+        <div class="container">
+            <div class="row row-cols-1 row-cols-sm-2 row-cols-md-3 g-3">
+                <div class="col" th:each="habit : ${habits}">
+                    <div class="card shadow-sm">
+                        <div class="card-body">
+                            <p class="card-text" style='overflow:hidden;white-space:nowrap;text-overflow:ellipsis' th:text="${habit.name}"></p>
+                            <p class="card-text" style='overflow:hidden;white-space:nowrap;text-overflow:ellipsis' th:text="${habit.content}"></p>
+                            <div class="d-flex justify-content-between align-items-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" th:text="${habit.hashtag}"></button>
+                                </div>
+                                <small class="text-muted" th:text="${habit.createdAt}"></small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+        <nav>
+            <table>
+                <td>
+
+                </td>
+            </table>
+        </nav>
+        prev 1 2 3 4 5 next
+    </main>
+
+    <footer th:replace="~{footer :: footer}"></footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/haveit/src/main/resources/templates/header.html
+++ b/haveit/src/main/resources/templates/header.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+
+<body>
+    <header>
+        교체된 header
+        <hr>
+    </header>
+</body>
+</html>

--- a/haveit/src/main/resources/templates/index.html
+++ b/haveit/src/main/resources/templates/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/haveit/src/test/java/com/mhc/haveit/controller/HabitControllerTest.java
+++ b/haveit/src/test/java/com/mhc/haveit/controller/HabitControllerTest.java
@@ -1,0 +1,46 @@
+package com.mhc.haveit.controller;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@DisplayName("View 컨트롤러 - 게시글")
+@WebMvcTest(HabitController.class)
+class HabitControllerTest {
+
+    private final MockMvc mvc;
+
+    public HabitControllerTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @Disabled("개발중")
+    @DisplayName("[view][GET] 습관 리스트 페이지 - 정상 호출")
+    @Test
+    void givenNothing_whenRequestingHabitsView_thenReturnsHabitsView() throws Exception {
+        mvc.perform(get("/habits"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.TEXT_HTML))
+                .andExpect(view().name("habits/index"))
+                .andExpect(model().attributeExists("habits"));
+    }
+
+    @Disabled("개발중")
+    @DisplayName("[view][GET] 습관 상세 페이지 - 정상 호출")
+    @Test
+    void givenNothing_whenRequestingHabitView_thenReturnsHabitView() throws Exception {
+        mvc.perform(get("/habits/1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.TEXT_HTML))
+                .andExpect(view().name("habits/detail"))
+                .andExpect(model().attributeExists("habit"));
+    }
+
+}

--- a/haveit/src/test/java/com/mhc/haveit/controller/HabitControllerTest.java
+++ b/haveit/src/test/java/com/mhc/haveit/controller/HabitControllerTest.java
@@ -1,10 +1,12 @@
 package com.mhc.haveit.controller;
 
+import com.mhc.haveit.config.SecurityConfig;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -13,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @DisplayName("View 컨트롤러 - 게시글")
 @WebMvcTest(HabitController.class)
+@Import(SecurityConfig.class)
 class HabitControllerTest {
 
     private final MockMvc mvc;
@@ -21,13 +24,12 @@ class HabitControllerTest {
         this.mvc = mvc;
     }
 
-    @Disabled("개발중")
     @DisplayName("[view][GET] 습관 리스트 페이지 - 정상 호출")
     @Test
     void givenNothing_whenRequestingHabitsView_thenReturnsHabitsView() throws Exception {
         mvc.perform(get("/habits"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.TEXT_HTML))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("habits/index"))
                 .andExpect(model().attributeExists("habits"));
     }
@@ -38,7 +40,7 @@ class HabitControllerTest {
     void givenNothing_whenRequestingHabitView_thenReturnsHabitView() throws Exception {
         mvc.perform(get("/habits/1"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.TEXT_HTML))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("habits/detail"))
                 .andExpect(model().attributeExists("habit"));
     }

--- a/haveit/src/test/java/com/mhc/haveit/controller/HabitControllerTest.java
+++ b/haveit/src/test/java/com/mhc/haveit/controller/HabitControllerTest.java
@@ -1,37 +1,58 @@
 package com.mhc.haveit.controller;
 
 import com.mhc.haveit.config.SecurityConfig;
+import com.mhc.haveit.service.HabitService;
+import com.mhc.haveit.service.PaginationService;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 @DisplayName("View 컨트롤러 - 게시글")
-@WebMvcTest(HabitController.class)
 @Import(SecurityConfig.class)
+@WebMvcTest(HabitController.class)
 class HabitControllerTest {
 
     private final MockMvc mvc;
+    @MockBean private HabitService habitService;
+    @MockBean private PaginationService paginationService;
 
-    public HabitControllerTest(@Autowired MockMvc mvc) {
-        this.mvc = mvc;
-    }
+    public HabitControllerTest(@Autowired MockMvc mvc) { this.mvc = mvc; }
 
     @DisplayName("[view][GET] 습관 리스트 페이지 - 정상 호출")
     @Test
     void givenNothing_whenRequestingHabitsView_thenReturnsHabitsView() throws Exception {
+        // Given
+        given(habitService.searchHabits(eq(null),eq(null), any(Pageable.class))).willReturn(Page.empty());
+        given(paginationService.getPaginationBarNumbers(anyInt(),anyInt())).willReturn(List.of(1,2,3,4,5));
+
+        // When & Then
         mvc.perform(get("/habits"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
                 .andExpect(view().name("habits/index"))
-                .andExpect(model().attributeExists("habits"));
+                .andExpect(model().attributeExists("habits"))
+                .andExpect(model().attributeExists("searchTypes"))
+                .andExpect(model().attributeExists("paginationBarNumbers"));
+        then(habitService).should().searchHabits(eq(null),eq(null), any(Pageable.class));
+        then(paginationService).should().getPaginationBarNumbers(anyInt(),anyInt());
     }
 
     @Disabled("개발중")

--- a/haveit/src/test/java/com/mhc/haveit/service/HabitServiceTest.java
+++ b/haveit/src/test/java/com/mhc/haveit/service/HabitServiceTest.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 
+@DisplayName("비즈니스 로직 - 습관")
 @ExtendWith(MockitoExtension.class)
 class HabitServiceTest {
 

--- a/haveit/src/test/java/com/mhc/haveit/service/HabitServiceTest.java
+++ b/haveit/src/test/java/com/mhc/haveit/service/HabitServiceTest.java
@@ -1,0 +1,223 @@
+package com.mhc.haveit.service;
+
+import com.mhc.haveit.domain.Habit;
+import com.mhc.haveit.domain.UserAccount;
+import com.mhc.haveit.domain.type.SearchType;
+import com.mhc.haveit.dto.HabitDto;
+import com.mhc.haveit.dto.UserAccountDto;
+import com.mhc.haveit.repository.HabitRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class HabitServiceTest {
+
+    @InjectMocks private HabitService sut;
+    @Mock private HabitRepository habitRepository;
+
+    @DisplayName("검색어 없이 습관목록을 검색하면, 습관페이지를 반환한다.")
+    @Test
+    void givenNothing_whenSearchingHabits_thenReturnsHabitsPage(){
+        // Given
+        Pageable pageable = Pageable.ofSize(12);
+        given(habitRepository.findAll(pageable)).willReturn(Page.empty());
+
+        // When
+        Page<HabitDto> habits = sut.searchHabits(null,null,pageable);
+
+        // Then
+        assertThat(habits).isEqualTo(Page.empty());
+        then(habitRepository).should().findAll(pageable);
+    }
+
+    @DisplayName("검색어와 함께 습관목록을 검색하면, 습관페이지를 반환한다.")
+    @Test
+    void givenSearchKeyword_whenSearchingHabits_thenReturnsHabitsPage(){
+        // Given
+        SearchType searchType = SearchType.ID;
+        String searchKeyword = "userId";
+        Pageable pageable = Pageable.ofSize(12);
+        given(habitRepository.findByUserAccount_UserIdContaining(searchKeyword,pageable)).willReturn(Page.empty());
+
+        // When
+        Page<HabitDto> habits = sut.searchHabits(searchType,searchKeyword,pageable);
+
+        // Then
+        assertThat(habits).isEqualTo(Page.empty());
+        then(habitRepository).should().findByUserAccount_UserIdContaining(searchKeyword,pageable);
+    }
+
+    @DisplayName("습관을 조회하면, 습관 상세페이지를 반환한다.")
+    @Test
+    void givenHabitId_whenSearchingHabit_thenReturnsHabit(){
+        // Given
+        Long habitId = 1L;
+        Habit habit = createHabit();
+        given(habitRepository.findById(habitId)).willReturn(Optional.of(habit));
+
+        // When
+        HabitDto dto = sut.getHabit(habitId);
+
+        // Then
+        assertThat(dto)
+                .hasFieldOrPropertyWithValue("name",habit.getName())
+                .hasFieldOrPropertyWithValue("content", habit.getContent())
+                .hasFieldOrPropertyWithValue("hashtag",habit.getHashtag());
+        then(habitRepository).should().findById(habitId);
+    }
+
+    @DisplayName("없는 습관을 조회하면, 예외를 던진다.")
+    @Test
+    void givenNonexistentHabitId_whenSearchingHabit_thenThrowsException(){
+        // Given
+        Long habitId = 0L;
+
+        // When
+        Throwable t = catchThrowable(()-> sut.getHabit(habitId));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessage("존재하지 않는 습관입니다. - habitId:"+habitId);
+        then(habitRepository).should().findById(habitId);
+    }
+
+    @DisplayName("습관 정보를 입력하면, 습관을 생성한다.")
+    @Test
+    void givenHabitInfo_whenSavingHabit_thenSavesHabit(){
+        // Given
+        HabitDto habitDto = createHabitDto("study","content","java");
+        given(habitRepository.save(any(Habit.class))).willReturn(createHabit());
+
+        // When
+        sut.saveHabit(habitDto);
+
+        // Then
+        then(habitRepository).should().save(any(Habit.class));
+    }
+
+    @DisplayName("습관의 수정 정보를 입력하면, 습관을 수정한다.")
+    @Test
+    void givenModifiedHabitInfo_whenUpdatingHabit_thenUpdatesHabit(){
+        // Given
+        Habit habit = createHabit();
+        HabitDto dto = createHabitDto("walk","hardWalking","#health");
+        given(habitRepository.findById(dto.getId())).willReturn(Optional.ofNullable(habit));
+
+        // When
+        sut.updateHabit(dto);
+
+        // Then
+        assertThat(habit.getName()).isEqualTo("walk");
+        assertThat(habit)
+                .hasFieldOrPropertyWithValue("name",dto.getName())
+                .hasFieldOrPropertyWithValue("content",dto.getContent())
+                .hasFieldOrPropertyWithValue("hashtag",dto.getHashtag());
+        then(habitRepository).should().findById(dto.getId());
+    }
+
+    @DisplayName("없는 습관의 수정 정보를 입력하면, 예외를 던지고 아무것도 하지않는다.")
+    @Test
+    void givenNonexistentHabitInfo_whenUpdatingHabit_thenThrowsExceptionAndDoseNothing(){
+        // Given
+        HabitDto dto = createHabitDto("walk","hardWalking","#health");
+        given(habitRepository.findById(dto.getId())).willReturn(Optional.empty());
+
+        // When
+        Throwable t = catchThrowable(()-> sut.updateHabit(dto));
+
+        // Then
+        assertThat(t)
+                .isInstanceOf(EntityNotFoundException.class)
+                        .hasMessage("습관 업데이트 실패. 습관을 찾을 수 없습니다 - dto: "+dto);
+        then(habitRepository).should().findById(dto.getId());
+    }
+
+    @DisplayName("습관의 ID 를 입력하면, 습관을 삭제한다.")
+    @Test
+    void givenHabitId_whenDeletingHabit_thenDeletesHabit(){
+        // Given
+        Long habitId = 1L;
+        willDoNothing().given(habitRepository).deleteById(habitId);
+
+        // When
+        sut.deleteHabit(habitId);
+
+        // Then
+        then(habitRepository).should().deleteById(habitId);
+    }
+
+    @DisplayName("습관의 수를 조회하면, 습관의 총 수를 반환한다.")
+    @Test
+    void givenNothing_whenCountingHabits_thenReturnsHabitCount(){
+        // Given
+        Long expected = 0L;
+        given(habitRepository.count()).willReturn(expected);
+
+        // When
+        Long actual = sut.getHabitCount();
+
+        // Then
+        assertThat(actual).isEqualTo(expected);
+        then(habitRepository).should().count();
+    }
+
+
+    private HabitDto createHabitDto(String name, String content, String hashtag){
+        return HabitDto.builder()
+                .id(1L)
+                .name(name)
+                .userAccountDto(createUserAccountDto())
+                .content(content)
+                .hashtag(hashtag)
+                .createdAt(LocalDateTime.now())
+                .createdBy("jsh")
+                .modifiedAt(LocalDateTime.now())
+                .modifiedBy("jsh")
+                .build();
+    }
+    private Habit createHabit(){
+        return Habit.builder()
+                .name("Spring")
+                .userAccount(createuserAccount())
+                .content("study")
+                .hashtag("#java")
+                .build();
+    }
+
+    private UserAccountDto createUserAccountDto(){
+        return UserAccountDto.builder()
+                .id(1L)
+                .nickname("Jeong")
+                .email("jsh@mail.com")
+                .memo("memo")
+                .createdAt(LocalDateTime.now())
+                .createdBy("jsh")
+                .modifiedAt(LocalDateTime.now())
+                .modifiedBy("jsh")
+                .build();
+    }
+
+    private UserAccount createuserAccount(){
+        return UserAccount.builder()
+                .nickname("Jeong")
+                .email("jsh@mail.com")
+                .memo("memo")
+                .build();
+    }
+}

--- a/haveit/src/test/java/com/mhc/haveit/service/PaginationServiceTest.java
+++ b/haveit/src/test/java/com/mhc/haveit/service/PaginationServiceTest.java
@@ -1,0 +1,51 @@
+package com.mhc.haveit.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+@DisplayName("비즈니스 로직 - 페이지네이션")
+@SpringBootTest(classes = PaginationService.class)
+class PaginationServiceTest {
+
+    private final PaginationService sut;
+
+    public PaginationServiceTest(@Autowired PaginationService sut) { this.sut = sut; }
+
+    @DisplayName("현재 페이지와 총 페이지 수를 주면, 바 리스트를 만들어준다.")
+    @MethodSource("providePageNumbers")
+    @ParameterizedTest(name = "[{index}] : {0}, {1} -> {2}")
+    void givenCurrentPageNumberAndTotalPages_whenCalculating_thenReturnsPaginationBarNumbers(int currentPageNumber, int totalPages, List<Integer> expect){
+        // Given
+
+        // When
+        List<Integer> actual = sut.getPaginationBarNumbers(currentPageNumber, totalPages);
+
+        // Then
+        assertThat(actual).isEqualTo(expect);
+    }
+
+    static Stream<Arguments> providePageNumbers(){
+        return Stream.of(
+                arguments(0, 13, List.of(0,1,2,3,4)),
+                arguments(1, 13, List.of(0,1,2,3,4)),
+                arguments(2, 13, List.of(0,1,2,3,4)),
+                arguments(3, 13, List.of(1,2,3,4,5)),
+                arguments(4, 13, List.of(2,3,4,5,6)),
+                arguments(5, 13, List.of(3,4,5,6,7)),
+                arguments(6, 13, List.of(4,5,6,7,8)),
+                arguments(10, 13, List.of(8,9,10,11,12)),
+                arguments(11, 13, List.of(9,10,11,12)),
+                arguments(12, 13, List.of(10,11,12))
+        );
+    }
+}


### PR DESCRIPTION
습관목록 페이지의 view와 기능을 추가하였습니다.

내역
* 습관목록 기능과 테스트를 정의
   * 필요한 view 작성
* 검색 기능 (제목, 아이디, 닉네임, 해시태그)
* pagination 기능
* 습관목록의 해시태그를 누를 시 해당 해시태그로 검색
* 검색을 하고 검색어가 검색 바에 남도록 수정

TODO
* 습관 목록을 생성하는 view, 기능 만들기
* 습관 상세페이지 view,기능 만들기


<img width="1421" alt="image" src="https://github.com/MHC-1Day/1Day/assets/31503178/6f59af52-cebd-4706-82f2-c07c06290b69">
